### PR TITLE
feat: Setting innerRef on InternalLinkElement instead of ref

### DIFF
--- a/pkg/src/components/Link.js
+++ b/pkg/src/components/Link.js
@@ -1,4 +1,4 @@
-import React, { useEffect, memo } from "react";
+import React, { memo } from "react";
 import PropTypes from "prop-types";
 import clsx from "clsx";
 
@@ -112,6 +112,11 @@ function Link({
   let attributes =
     typeof Component === "string" ? filterAttributes(restProps) : restProps;
 
+  const refAttribute =
+    typeof Component === "function" && Component.name === "InternalLinkElement"
+      ? { innerRef: innerRef }
+      : { ref: innerRef };
+
   return (
     <Component
       href={href}
@@ -126,7 +131,7 @@ function Link({
           : undefined
       }
       {...attributes}
-      ref={innerRef}
+      {...refAttribute}
     >
       {children}
       {target === "_blank" && (

--- a/pkg/src/components/TreeMenu.js
+++ b/pkg/src/components/TreeMenu.js
@@ -148,10 +148,10 @@ export default function TreeMenu({
     [items],
   );
 
-  const currentItemPath = useMemo(
-    () => findItemPath(isCurrentItem),
-    [isCurrentItem, findItemPath],
-  );
+  const currentItemPath = useMemo(() => findItemPath(isCurrentItem), [
+    isCurrentItem,
+    findItemPath,
+  ]);
 
   useEffect(() => {
     // Clear all expanded items

--- a/pkg/src/components/TreeMenu.js
+++ b/pkg/src/components/TreeMenu.js
@@ -29,11 +29,11 @@ TreeMenu.propTypes = {
 };
 
 function encodePath(path) {
-  return JSON.stringify(path);
+  return path && JSON.stringify(path);
 }
 
 function decodePath(path) {
-  return JSON.parse(path);
+  return path && JSON.parse(path);
 }
 
 function documentPositionComparator(a, b) {
@@ -148,10 +148,10 @@ export default function TreeMenu({
     [items],
   );
 
-  const currentItemPath = useMemo(() => findItemPath(isCurrentItem), [
-    isCurrentItem,
-    findItemPath,
-  ]);
+  const currentItemPath = useMemo(
+    () => findItemPath(isCurrentItem),
+    [isCurrentItem, findItemPath],
+  );
 
   useEffect(() => {
     // Clear all expanded items
@@ -167,11 +167,11 @@ export default function TreeMenu({
 
   const registerItemElement = useCallback((path, element) => {
     if (element == null) {
-      let prevElement = itemsRef.current[encodePath(path)];
+      let prevElement = itemsRef.current?.[encodePath(path)];
       if (prevElement === document.activeElement) {
-        focusDummyRef.current.focus();
+        focusDummyRef.current?.focus();
       }
-      delete itemsRef.current[encodePath(path)];
+      delete itemsRef.current?.[encodePath(path)];
     } else {
       itemsRef.current[encodePath(path)] = element;
       updateFocus();


### PR DESCRIPTION
Passing `ref` down to GatsbyLink made the tab navigation crash, passing `innerRef` instead.

Adding nullchecks when decoding and encoding path.