### PR TITLE
feat: Preventing submitting of forms on enter

### DIFF
--- a/pkg/src/components/FormInputField.js
+++ b/pkg/src/components/FormInputField.js
@@ -36,6 +36,9 @@ export default function FormInputField({
           <div className={styles.control}>
             <Field
               type={type}
+              onKeyDown={(e) => {
+                e.key === "Enter" && e.preventDefault();
+              }}
               className={styles.input}
               name={name}
               {...controlProps}


### PR DESCRIPTION
Apparently formik submits forms on enter, according to this thread you should disable it this way:

https://github.com/jaredpalmer/formik/issues/2907